### PR TITLE
Dsl draft

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,3 +19,7 @@ lazy val dsl = project
 lazy val parser = project
   .aggregate(model)
   .dependsOn(model)
+
+lazy val example = project
+  .aggregate(model, dsl, parser)
+  .dependsOn(model, dsl, parser)

--- a/dsl/src/main/scala/scalasvg/dsl/internal/package.scala
+++ b/dsl/src/main/scala/scalasvg/dsl/internal/package.scala
@@ -1,0 +1,24 @@
+package scalasvg.dsl
+
+import scala.collection.mutable.ListBuffer
+import scalasvg.element.Element
+
+package object internal {
+  type Initializer[T] = ListBuffer[T] ?=> Unit
+
+  private[dsl] def initialize[C, E <: Element[Seq[C]]](construct: Seq[C] => E, init: Initializer[C])
+                                                 (using parent: ListBuffer[_ >: E]): E = {
+    initializeParent(initializeChildren(construct, init))
+  }
+
+  private[dsl] def initializeChildren[C, E <: Element[Seq[C]]](construct: Seq[C] => E, init: Initializer[C]): E = {
+    val children = ListBuffer.empty[C]
+    init(using children)
+    construct(children.toSeq)
+  }
+
+  private[dsl] def initializeParent[E <: Element[_]](element: E)(using parent: ListBuffer[_ >: E]): E = {
+    parent.addOne(element)
+    element
+  }
+}

--- a/dsl/src/main/scala/scalasvg/dsl/package.scala
+++ b/dsl/src/main/scala/scalasvg/dsl/package.scala
@@ -1,0 +1,31 @@
+package scalasvg
+
+import scalasvg.attribute.Attribute
+import scalasvg.dsl.internal.{Initializer, initialize, initializeChildren, initializeParent}
+import scalasvg.element.{Circle, Desc, SVG, Plain}
+
+import scala.collection.mutable.ListBuffer
+
+package object dsl {
+  def svg(viewBox: String, attributes: SVG.Attribute*)
+         (init: Initializer[SVG.Content]): SVG = {
+    initializeChildren(SVG(viewBox, attributes, _), init)
+  }  
+
+  def circle(x: String, y: String, r: String, pathLength: Option[Number] = None, attributes: Circle.Attribute*)
+            (init: Initializer[Circle.Content])
+            (using parent: ListBuffer[_ >: Circle]): Circle = {
+    initialize(Circle(x, y, r, pathLength, attributes, _), init)
+  }
+
+  def desc(attributes: Desc.Attribute*)
+          (init: Initializer[Desc.Content])
+          (using parent: ListBuffer[_ >: Desc]): Desc = {
+    initialize(Desc(attributes, _), init)
+  }
+
+  def plain(text: String)
+           (using parent: ListBuffer[_ >: Plain]): Plain = {
+    initializeParent(Plain(text))
+  }
+}

--- a/example/src/main/scala/scalasvg.example/Main.scala
+++ b/example/src/main/scala/scalasvg.example/Main.scala
@@ -1,0 +1,23 @@
+package scalasvg.example
+
+import scalasvg.element.SVG
+import scalasvg.dsl.{svg, circle, desc, plain}
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val document: SVG =
+      svg(viewBox = "0 0 100 100") {
+        desc() {
+          plain("A description for the document.")
+        }
+        circle(x = "0", y = "0", r = "5px") {
+          desc() {
+            plain("A multiline description")
+            plain("for the circle.")
+          }
+        }
+      }
+
+    println(document)
+  }
+}

--- a/model/src/main/scala/scalasvg/element/Circle.scala
+++ b/model/src/main/scala/scalasvg/element/Circle.scala
@@ -10,8 +10,7 @@ import scalasvg.element.category.Category
   * @param r The radius of the circle. A value lower or equal to zero disables rendering of the circle.
   * @param pathLength The total length for the circle's circumference, in user units.
   */
-final case class Circle(cx: String, cy: String, r: String, pathLength: Option[Number]=None, attributes: Circle.Attribute*)
-    (content: Circle.Content*)
+final case class Circle(cx: String, cy: String, r: String, pathLength: Option[Number] = None, attributes: Seq[Circle.Attribute] = Seq.empty, content: Seq[Circle.Content])
     extends Element[Seq[Circle.Content]](content)
     with Category.BasicShape with Category.Graphics with Category.Shape
 

--- a/model/src/main/scala/scalasvg/element/Desc.scala
+++ b/model/src/main/scala/scalasvg/element/Desc.scala
@@ -6,7 +6,7 @@ import scalasvg.element.category.Category
 /**
   * The <desc> element provides an accessible, long-text description of any SVG container element or graphics element.
   */
-final case class Desc(attributes: Desc.Attribute*)(content: Desc.Content*)
+final case class Desc( attributes: Seq[Desc.Attribute] = Seq.empty, content: Seq[Desc.Content])
     extends Element[Seq[Desc.Content]](content)
     with Category.Descriptive
 

--- a/model/src/main/scala/scalasvg/element/Desc.scala
+++ b/model/src/main/scala/scalasvg/element/Desc.scala
@@ -16,5 +16,5 @@ object Desc {
     * @todo: Extend with all attributes of categories Global Event and Document Event
     */
   type Attribute = Core.Id | Styling.Class | Styling.Style
-  type Content = String | Element[Any]
+  type Content = Plain | Element[Any]
 }

--- a/model/src/main/scala/scalasvg/element/Ellipse.scala
+++ b/model/src/main/scala/scalasvg/element/Ellipse.scala
@@ -12,8 +12,7 @@ import scalasvg.element.category.Category
   * @param ry The radius of the ellipse on the y axis.
   * @param pathLength This attribute lets specify the total length for the path, in user units.
   */
-final case class Ellipse(cx: String, cy: String, rx: String, ry: String, pathLength: Option[Number]=None, attributes: Ellipse.Attribute*)
-    (content: Ellipse.Content*)
+final case class Ellipse(cx: String, cy: String, rx: String, ry: String, pathLength: Option[Number] = None, attributes: Seq[Ellipse.Attribute], content: Seq[Ellipse.Content])
     extends Element[Seq[Ellipse.Content]](content)
     with Category.BasicShape with Category.Graphics with Category.Shape
 

--- a/model/src/main/scala/scalasvg/element/Line.scala
+++ b/model/src/main/scala/scalasvg/element/Line.scala
@@ -11,8 +11,7 @@ import scalasvg.element.category.Category
   * @param y2 Defines the y-axis coordinate of the line ending point.
   * @param pathLength Defines the total path length in user units.
   */
-final case class Line(x1: String, x2: String, y1: String, y2: String, pathLength: Option[Number]=None, attributes: Line.Attribute*)
-    (content: Line.Content*)
+final case class Line(x1: String, x2: String, y1: String, y2: String, pathLength: Option[Number] = None, attributes: Seq[Line.Attribute], content: Seq[Line.Content])
     extends Element[Seq[Line.Content]](content)
     with Category.BasicShape with Category.Graphics with Category.Shape
 

--- a/model/src/main/scala/scalasvg/element/Plain.scala
+++ b/model/src/main/scala/scalasvg/element/Plain.scala
@@ -1,0 +1,3 @@
+package scalasvg.element
+
+final case class Plain(value: String) extends Element[String](value)

--- a/model/src/main/scala/scalasvg/element/Polygon.scala
+++ b/model/src/main/scala/scalasvg/element/Polygon.scala
@@ -10,8 +10,7 @@ import scalasvg.element.category.Category
   * required to draw the polygon.
   * @param pathLength This attribute lets specify the total length for the path, in user units.
   */
-final case class Polygon(points: List[(String,String)], pathLength: Option[Number]=None, attributes: Polygon.Attribute*)
-    (content: Polygon.Content*)
+final case class Polygon(points: List[(String,String)], pathLength: Option[Number] = None, attributes: Seq[Polygon.Attribute], content: Seq[Polygon.Content])
     extends Element[Seq[Polygon.Content]](content)
     with Category.BasicShape with Category.Graphics with Category.Shape
 

--- a/model/src/main/scala/scalasvg/element/Polyline.scala
+++ b/model/src/main/scala/scalasvg/element/Polyline.scala
@@ -11,8 +11,7 @@ import scalasvg.element.category.Category
   * required to draw the polyline.
   * @param pathLength This attribute lets specify the total length for the path, in user units.
   */
-final case class Polyline(points: List[(String,String)], pathLength: Option[Number]=None, attributes: Polyline.Attribute*)
-    (content: Polyline.Content*)
+final case class Polyline(points: List[(String,String)], pathLength: Option[Number] = None, attributes: Seq[Polyline.Attribute], content: Seq[Polyline.Content])
     extends Element[Seq[Polyline.Content]](content)
     with Category.BasicShape with Category.Graphics with Category.Shape
 

--- a/model/src/main/scala/scalasvg/element/Rect.scala
+++ b/model/src/main/scala/scalasvg/element/Rect.scala
@@ -14,8 +14,8 @@ import scalasvg.element.category.Category
   * @param ry The vertical corner radius of the rect. Defaults to rx if it is specified.
   * @param pathLength The total length of the rectangle's perimeter, in user units.
   */
-final case class Rect(x: String, y: String, width: String, height: String, rx: String, ry: String, pathLength: Option[Number]=None, 
-    attributes: Rect.Attribute*)(content: Rect.Content*)
+final case class Rect(x: String, y: String, width: String, height: String, rx: String, ry: String, pathLength: Option[Number] = None, 
+    attributes: Seq[Rect.Attribute], content: Seq[Rect.Content])
     extends Element[Seq[Rect.Content]](content)
     with Category.BasicShape with Category.Graphics with Category.Shape
 

--- a/model/src/main/scala/scalasvg/element/SVG.scala
+++ b/model/src/main/scala/scalasvg/element/SVG.scala
@@ -1,0 +1,15 @@
+package scalasvg.element
+
+import scalasvg.element.category.Category
+
+final case class SVG(viewBox: String, attributes: Seq[SVG.Attribute], content: Seq[SVG.Content])
+  extends Element[Seq[SVG.Content]](content)
+  with Category.Container
+  with Category.Renderable
+  with Category.Structural
+
+
+object SVG {
+  type Attribute = scalasvg.attribute.Attribute
+  type Content = Category.Animation | Category.Descriptive | Category.Shape | Category.Structural | Category.Gradient
+}


### PR DESCRIPTION
This pull-request suggests a way to deal with the `dsl` for the `scalasvg` model.
```scala
svg(viewBox = "0 0 100 100") {
  desc() {
    plain("A description for the document.")
  }
  circle(x = "0", y = "0", r = "5px") {
    desc() {
      plain("A multiline description")
      plain("for the circle.")
    }
  }
}
```

After trying it myself I thought that it would be better to move all the parameters of `_ <: Element[_]` classes to the first parameters group since they all are case classes and all the significant parameters should be put into the first group (scala derives `hashCode`, `equals` and `toString` based only on the first group of parameters).

I also added the `example` project for demonstration purposes, one could run the `Main` class and see the resulting document structure produced by the `dsl`:
```bash
sbt example/run
```