### PR TITLE
ScalaTest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,15 +12,19 @@ ThisBuild / scalacOptions := Seq(
 ThisBuild / useScala3doc := true
 
 lazy val model = project
+  .settings(libraryDependencies ++= Dependencies.Model)
 
 lazy val dsl = project
   .aggregate(model)
   .dependsOn(model)
+  .settings(libraryDependencies ++= Dependencies.Dsl)
 
 lazy val parser = project
   .aggregate(model)
   .dependsOn(model)
+  .settings(libraryDependencies ++= Dependencies.Parser)
 
 lazy val example = project
   .aggregate(model, dsl, parser)
   .dependsOn(model, dsl, parser)
+  .settings(libraryDependencies ++= Dependencies.Example)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,13 +1,25 @@
 import sbt._
 
 object Dependencies {
-  private object Version {
-    final val scalatest = "3.2.0"
+  private val TestDependencies = Seq(
+    D.scalatestWordspec,
+    D.scalatestMustmatchers
+  ).map(_ % Test)
+
+  val Model: Seq[ModuleID] = TestDependencies
+
+  val Dsl: Seq[ModuleID] = TestDependencies
+
+  val Parser: Seq[ModuleID] = TestDependencies
+
+  val Example: Seq[ModuleID] = TestDependencies
+
+  private object V {
+    val scalatest = "3.2.3"
   }
 
-  private val `scalatest-wordspec`     = "org.scalatest" % "scalatest-wordspec"     % Version.scalatest % Test
-  private val `scalatest-mustmatchers` = "org.scalatest" % "scalatest-mustmatchers" % Version.scalatest % Test
-
-  /* @todo: Enable test dependencies once the compilcation error on the library side is fixed */
-  // val Model = Seq(`scalatest-wordspec`, `scalatest-mustmatchers`)
+  private object D {
+    val scalatestWordspec     = "org.scalatest" %% "scalatest-wordspec"     % V.scalatest
+    val scalatestMustmatchers = "org.scalatest" %% "scalatest-mustmatchers" % V.scalatest
+  }
 }


### PR DESCRIPTION
This pull request adds test-dependencies to the project.  As test style, I chose `WordSpec`-style and for matchers `Must`-matchers. If you disagree with my choice, please, fill free to comment and suggest any other option.

Everything works fine, tested in a `dsl` module with the following blank test:
```scala
package scalasvg.dsl

import org.scalatest.wordspec.AnyWordSpec
import org.scalatest.matchers.must.Matchers

class ExampleSpec extends AnyWordSpec with Matchers {
 "Example" should {
   "do math" in {
     (1 + 1) must be (2)
   }
 }
}
```

*See:*
- `scalatest` documentation for `WordSpec`: https://www.scalatest.org/scaladoc/3.2.2/org/scalatest/wordspec/AnyWordSpec.html
- `scalatest` documentation for `must.Matchers`: https://www.scalatest.org/scaladoc/3.2.2/org/scalatest/matchers/must/Matchers.html 